### PR TITLE
Cleanup and debian deps

### DIFF
--- a/Network/Gitit2/Helper.hs
+++ b/Network/Gitit2/Helper.hs
@@ -10,14 +10,13 @@ module Network.Gitit2.Helper (
 
 import Control.Applicative ((<$>))
 import Control.Exception (handle, throw)
+import Control.Monad (filterM)
 import Data.ByteString.Lazy (ByteString)
-import Data.FileStore (FileStoreError(NotFound), retrieve, RevisionId)
+import Data.FileStore (index, FileStoreError(NotFound), retrieve, RevisionId)
 import Network.Gitit2.Foundation (config, filestore, GititConfig, GH, HasGitit, page_extension)
 import Network.Gitit2.Page (pathForPageP, pageForPathP, Page)
 import System.FilePath (takeExtension)
 import Yesod (getYesod, liftIO)
-import Data.FileStore (index)
-import Control.Monad (filterM)
 
 getConfig :: GH master GititConfig
 getConfig = config <$> getYesod

--- a/Network/Gitit2/Page.hs
+++ b/Network/Gitit2/Page.hs
@@ -1,15 +1,12 @@
 module Network.Gitit2.Page
        where
 
-import Yesod (PathMultiPiece, toMessage, ToMessage)
-import Text.Blaze (toMarkup, ToMarkup)
+import           Data.Monoid ((<>))
+import           Data.Text (Text)
 import qualified Data.Text as T
-import Data.Text (Text)
-import Yesod (toPathMultiPiece)
-import Yesod (fromPathMultiPiece)
-import Data.Monoid ((<>))
-import System.FilePath (takeExtension)
-import System.FilePath (dropExtension)
+import           System.FilePath (dropExtension, takeExtension)
+import           Text.Blaze (toMarkup, ToMarkup)
+import           Yesod (fromPathMultiPiece, PathMultiPiece, toMessage, ToMessage, toPathMultiPiece)
 
 -- | Path to a wiki page.  Page and page components can't begin with '_'.
 data Page = Page [Text] deriving (Show, Read, Eq)

--- a/Network/Gitit2/WikiPage.hs
+++ b/Network/Gitit2/WikiPage.hs
@@ -69,7 +69,7 @@ contentToWikiPage' title contents converter defaultFormat =
            , wpFormat      = format
            , wpTOC         = toc
            , wpLHS         = lhs
-           , wpTitle       = toList $ text $ T.unpack $ title
+           , wpTitle       = toList $ text $ T.unpack title
            , wpCategories  = extractCategories metadata
            , wpMetadata    = metadata
            , wpCacheable   = True
@@ -109,7 +109,7 @@ contentToWikiPage' title contents converter defaultFormat =
     convertWikiLinks x = x
 
     addWikiLinks :: Pandoc -> Pandoc
-    addWikiLinks = bottomUp (convertWikiLinks)
+    addWikiLinks = bottomUp convertWikiLinks
 
     stripHeader :: [ByteString] -> (ByteString,ByteString)
     stripHeader (x:xs)

--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,8 @@ Hacking gitit2
 Here are some notes for those who want to modify or
 add to the code.
 
-* The library is all in one file, `Network/Gitit.hs`.
+* The library is in `Network/Gitit.hs`.
 * The executable, which uses the library, is in `src/gitit.hs`.
-* There are no longer any templates.  The HTML is produced
-  by hamlet code in `Network/Gitit.hs`.
+* On Debian you might want to install these build dependencies with
+  the operating systems package manager:
+  libzip-dev happy, alex

--- a/gitit2.cabal
+++ b/gitit2.cabal
@@ -47,6 +47,11 @@ flag executable
   description:   Build the gitit executable.
   default:       True
 
+flag debian-jessie
+  description: Use build dependencies available in Debian Jessie
+  default: False
+  manual: True
+
 library
     exposed-modules: Network.Gitit2
                      Network.Gitit2.Foundation
@@ -90,10 +95,6 @@ library
                  , text                          >= 0.11       && < 1.3
                  , template-haskell
                  , hamlet                        >= 1.1        && < 1.3
-                 , shakespeare                   >= 2.0        && < 2.1
-                 , shakespeare-css               >= 1.0        && < 1.2
-                 , shakespeare-js                >= 1.2        && < 1.4
-                 , shakespeare-text              >= 1.0        && < 1.2
                  , hjsmin                        >= 0.1        && < 0.2
                  , monad-control                 >= 0.3        && < 1.1
                  , wai-extra                     >= 2.1        && < 3.1
@@ -119,6 +120,12 @@ library
                  , blaze-builder                 >= 0.3        && < 0.5
                  , pandoc-types                  >= 1.12       && < 1.13
                  , HTTP                          >= 4000.2     && < 4000.3
+    if flag(debian-jessie)
+      Build-Depends: shakespeare-css               >= 1.0        && < 1.2
+                   , shakespeare-js                >= 1.2        && < 1.4
+                   , shakespeare-text              >= 1.0        && < 1.2
+    else
+      Build-Depends: shakespeare                   >= 2.0        && < 2.1
 
     ghc-options:  -Wall -fno-warn-unused-do-bind
 


### PR DESCRIPTION
The debian-haskell team will move to base its packaging on stackage. So in the future we might have only cabal flags to compile on different stackage versions and not clutter cabal with all kinds of operating-system flags. - But please accept the debian-jessie flag for the moment.